### PR TITLE
haXe was renamed to Haxe

### DIFF
--- a/vendor/pygments-main/pygments/lexers/_mapping.py
+++ b/vendor/pygments-main/pygments/lexers/_mapping.py
@@ -111,7 +111,7 @@ LEXERS = {
     'GroovyLexer': ('pygments.lexers.jvm', 'Groovy', ('groovy',), ('*.groovy',), ('text/x-groovy',)),
     'HamlLexer': ('pygments.lexers.web', 'Haml', ('haml', 'HAML'), ('*.haml',), ('text/x-haml',)),
     'HaskellLexer': ('pygments.lexers.functional', 'Haskell', ('haskell', 'hs'), ('*.hs',), ('text/x-haskell',)),
-    'HaxeLexer': ('pygments.lexers.web', 'haXe', ('hx', 'haXe'), ('*.hx',), ('text/haxe',)),
+    'HaxeLexer': ('pygments.lexers.web', 'Haxe', ('hx', 'haXe','haxe','Haxe'), ('*.hx',), ('text/haxe',)),
     'HtmlDjangoLexer': ('pygments.lexers.templates', 'HTML+Django/Jinja', ('html+django', 'html+jinja'), (), ('text/html+django', 'text/html+jinja')),
     'HtmlGenshiLexer': ('pygments.lexers.templates', 'HTML+Genshi', ('html+genshi', 'html+kid'), (), ('text/html+genshi',)),
     'HtmlLexer': ('pygments.lexers.web', 'HTML', ('html',), ('*.html', '*.htm', '*.xhtml', '*.xslt'), ('text/html', 'application/xhtml+xml')),

--- a/vendor/pygments-main/pygments/lexers/web.py
+++ b/vendor/pygments-main/pygments/lexers/web.py
@@ -1111,8 +1111,8 @@ class HaxeLexer(RegexLexer):
     For haXe source code (http://haxe.org/).
     """
 
-    name = 'haXe'
-    aliases = ['hx', 'haXe']
+    name = 'Haxe'
+    aliases = ['hx', 'Haxe','haxe','haXe']
     filenames = ['*.hx']
     mimetypes = ['text/haxe']
 


### PR DESCRIPTION
haXe was renamed to Haxe, so I changed all occurrences accordingly. I left in the old spelling for all the projects that haven't change until now.

Source: https://groups.google.com/d/msg/haxelang/O7PB-ZrX4i4/uL69CT44C-IJ
