### PR TITLE
Support content-only lexer_name_for.

### DIFF
--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -66,7 +66,8 @@ class Mentos(object):
             - 'lexer' ("python")
             - 'mimetype' ("text/x-ruby")
             - 'filename' ("yeaaah.py")
-            - 'code' ("import derp" etc)
+
+        The code argument should be a string, such as "import derp".
 
         The code guessing method is not especially great. It is advised that
         clients pass in a literal lexer name whenever possible, which provides
@@ -101,7 +102,7 @@ class Mentos(object):
             return lexers.guess_lexer(code, **inputs)
 
         else:
-            _write_error("No lexer")
+            return None
 
 
     def highlight_text(self, code, lexer, formatter_name, args, kwargs):
@@ -186,7 +187,7 @@ class Mentos(object):
                     _write_error("No lexer")
 
             else:
-                _write_error("No lexer")
+                _write_error("Invalid method " + method)
 
             return res
 
@@ -294,7 +295,7 @@ class Mentos(object):
                 text = sys.stdin.read(_bytes)
 
                 # Sanity check the return.
-                if method == 'highlight':
+                if _bytes:
                     start_id, end_id = self._get_ids(text)
                     text = self._check_and_return_text(text, start_id, end_id)
 

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -158,7 +158,13 @@ module Pygments
         opts = {}
       end
 
-      mentos(:lexer_name_for, args, opts)
+      if args.last.is_a?(String)
+        code = args.pop
+      else
+        code = nil
+      end
+
+      mentos(:lexer_name_for, args, opts, code)
     end
 
     # Public: Highlight code.

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -171,6 +171,10 @@ class PygmentsLexerTest < Test::Unit::TestCase
     assert_equal 'rb', P.lexer_name_for(RUBY_CODE, :filename => 'test.rb')
   end
 
+  def test_lexer_by_content
+    assert_equal 'rb', P.lexer_name_for(RUBY_CODE)
+  end
+
   def test_lexer_by_nothing
     assert_raise MentosError do
       P.lexer_name_for(:invalid => true)


### PR DESCRIPTION
Thank you very much for the new pipe-based approach in pygments 0.3! rubypython kept crashing my Rails processes, so I had to disable syntax highlighting and wait for this.

Unfortunately, the piping changes lost support for passing code, with no metadata, into lexer_name_for.

This patch adds that support back, together with a (previously failing) test.

I hope you'll consider merging this patch. Please let me know if there are formatting / naming / other issues I can address. Thanks!
