### PR TITLE
use python2 instead of python

### DIFF
--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys, re, os, signal, resource


### PR DESCRIPTION
I run Arch Linux in production, which uses Python 3 for its `/usr/bin/python`.

`mentos.py` should explicitly state that it wants Python 2.
