### PR TITLE
Allow to use non-default python

### DIFF
--- a/lib/pygments.rb
+++ b/lib/pygments.rb
@@ -2,6 +2,16 @@ require File.join(File.dirname(__FILE__), 'pygments/popen')
 
 
 module Pygments
+  class << self
+    attr_accessor :python_path
+  end
+
+  if RUBY_PLATFORM =~ /mswin|mingw/
+    @python_path = "python"
+  else
+    @python_path = "/usr/bin/python"
+  end
+
   extend Pygments::Popen
 
   autoload :Lexer, 'pygments/lexer'

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -36,8 +36,7 @@ module Pygments
 
       # A pipe to the mentos python process. #popen4 gives us
       # the pid and three IO objects to write and read.
-      script = File.expand_path('../mentos.py', __FILE__)
-      script = 'python ' + script if is_windows
+      script = Pygments.python_path + ' ' + File.expand_path('../mentos.py', __FILE__)
       @pid, @in, @out, @err = popen4(script)
       @log.info "[#{Time.now.iso8601}] Starting pid #{@pid.to_s} with fd #{@out.to_i.to_s}."
     end


### PR DESCRIPTION
example:

Pygments.python_path = "/usr/bin/python2.6"
...
Pygments::Lexer[:js].highlight( .. )
