### PR TITLE
 Force the mentos.py to use python2

### DIFF
--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys, re, os, signal


### PR DESCRIPTION
The mentos.py should be forced to use python2,
because Archlinux and some other operation systems use python3 as the default version instead of python2.
#45 and #49 could be solved.
