### PR TITLE
Add Python 3 support for pygments.rb

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,0 +1,12 @@
+require 'mkmf'
+
+# If Python 3 is set as default, port vendor through 2to3.
+if `python -c 'import sys; print(sys.version[0])'`.start_with? '3'
+  system('cd ../vendor/pygments-main/' +
+    ' && 2to3 -w .' +
+    ' && 2to3 -w -d .' +
+    ' && 2to3 -w -d docs/src/*.txt')
+
+end
+
+create_makefile('pygments.rb')

--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'posix-spawn', '~> 0.3.6'
   s.add_development_dependency 'rake-compiler', '~> 0.7.6'
 
-  # s.extensions = ['ext/extconf.rb']
+  s.extensions = ['ext/extconf.rb']
   s.require_paths = ['lib']
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
This PR adds fully support for Python 3, which could solve all those annoying Python 3-related issues (especially on a distro where the default `python` is 3.x, like Gentoo or Arch. after tired of the temporary `#!/usr/bin/env python2` hack.):
#45, #49, #58, #59

[mentos.py](https://github.com/soimort/pygments.rb/blob/add_py3k_support/lib/pygments/mentos.py) is now made runnable under both Python 2 and 3.

On a system where the default `python` is 2.x, [vendor/pygments-main](https://github.com/soimort/pygments.rb/tree/add_py3k_support/vendor/pygments-main) will be bundled unchanged as before. When the default `python` is 3.x, the code in [vendor/pygments-main](https://github.com/soimort/pygments.rb/tree/add_py3k_support/vendor/pygments-main) will be run through `2to3` after gem installed (just as the installation of Python 3  Pygments did), using [ext/extconf.rb](https://github.com/soimort/pygments.rb/blob/add_py3k_support/ext/extconf.rb).

The only thing I didn't port is the test part, due to the original vendor code is Python 2 only. There's no way to test it on Python 3 without running it through `2to3`.

To test it on a Python 3-default system, build and install the gem first, then change a line in `popen.rb` to something like: (for using the `2to3`-ported vendor code)

``` py
ENV['PYGMENTS_PATH'] = '/home/user/.rvm/gems/ruby-2.0.0-p0/gems/pygments.rb-x.y.z/'
```

then all tests shall pass.
