### PR TITLE
Add GitLab formatter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -62,5 +62,14 @@ namespace :vendor do
     FileUtils.cd(LEXERS_DIR) { sh "python _mapping.py" }
   end
 
-  task :update => [:clobber, 'vendor/pygments-main', :load_lexers]
+  # Load all the custom formatters in the `vendor/custom_formatters` folder
+  # and stick them in our custom Pygments vendor
+  task :load_formatters do
+    FORMATTERS_DIR = 'vendor/pygments-main/pygments/formatters'
+    formatters = FileList['vendor/custom_formatters/*.py']
+    formatters.each { |f| FileUtils.copy f, FORMATTERS_DIR }
+    FileUtils.cd(FORMATTERS_DIR) { sh "python _mapping.py" }
+  end
+
+  task :update => [:clobber, 'vendor/pygments-main', :load_lexers, :load_formatters]
 end

--- a/vendor/pygments-main/pygments/formatters/_mapping.py
+++ b/vendor/pygments-main/pygments/formatters/_mapping.py
@@ -15,6 +15,7 @@
 
 # start
 from pygments.formatters.bbcode import BBCodeFormatter
+from pygments.formatters.gitlab import GitlabFormatter
 from pygments.formatters.html import HtmlFormatter
 from pygments.formatters.img import BmpImageFormatter
 from pygments.formatters.img import GifImageFormatter
@@ -32,6 +33,7 @@ FORMATTERS = {
     BBCodeFormatter: ('BBCode', ('bbcode', 'bb'), (), 'Format tokens with BBcodes. These formatting codes are used by many bulletin boards, so you can highlight your sourcecode with pygments before posting it there.'),
     BmpImageFormatter: ('img_bmp', ('bmp', 'bitmap'), ('*.bmp',), 'Create a bitmap image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),
     GifImageFormatter: ('img_gif', ('gif',), ('*.gif',), 'Create a GIF image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),
+    GitlabFormatter: ('GitLab', ('gitlab',), (), 'GitLab specific formatter for HTML output.'),
     HtmlFormatter: ('HTML', ('html',), ('*.html', '*.htm'), "Format tokens as HTML 4 ``<span>`` tags within a ``<pre>`` tag, wrapped in a ``<div>`` tag. The ``<div>``'s CSS class can be set by the `cssclass` option."),
     ImageFormatter: ('img', ('img', 'IMG', 'png'), ('*.png',), 'Create a PNG image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),
     JpgImageFormatter: ('img_jpg', ('jpg', 'jpeg'), ('*.jpg',), 'Create a JPEG image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),


### PR DESCRIPTION
Adds the HTML formatter used by [GitLab](gitlabhq/gitlabhq). (also see gitlabhq/pygments.rb#1)
- produces more lightweight HTML code
- allows for linking/highlighting of lines after rendering is done (see gitlabhq/gitlabhq#1937)
- the formatter itself is a lot simpler
- makes packaging GitLab easier for distos :wink: (see https://github.com/gitlabhq/pygments.rb/pull/1#commitcomment-3399722)
