### PR TITLE
When runtime require '/bin/sh' for backtick on windows, ignore errors and use 'python' gracefully.

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -48,6 +48,8 @@ module Pygments
       @python_binary ||= begin
         `which python2`
         $?.success? ? "python2" : "python"
+      rescue
+        'python'
       end
     end
 


### PR DESCRIPTION
It seens that ruby-2.0.0 or some gems which uses on jekyll require `/bin/sh` for backtick (backquote?) on windows.
But I don't have `/bin/sh` on my windows. Then, I hope pygments ignore errors, and use `python` gracefully.
