### PR TITLE
Use cliver gem for detecting python 2 binary

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 require 'posix/spawn'
+require 'cliver'
 require 'yajl'
 require 'timeout'
 require 'logger'
@@ -46,8 +47,7 @@ module Pygments
     # something like that.
     def python_binary
       @python_binary ||= begin
-        `which python2`
-        $?.success? ? "python2" : "python"
+        Cliver.detect('python2') || Cliver.detect!('python', '~> 2.0')
       end
     end
 

--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'yajl-ruby',   '~> 1.1.0'
   s.add_dependency 'posix-spawn', '~> 0.3.6'
+  s.add_dependency 'cliver',      '~> 0.2.0'
   s.add_development_dependency 'rake-compiler', '~> 0.7.6'
 
   # s.extensions = ['ext/extconf.rb']

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -263,6 +263,14 @@ class PygmentsCssTest < Test::Unit::TestCase
 end
 
 class PygmentsConfigTest < Test::Unit::TestCase
+  def test_python_missing
+    path_backup = ENV['PATH']
+    ENV['PATH'] = '/foo/bar:foo/bingo' # make python be not found.
+    assert_raise(Cliver::Dependency::NotFound) { P::Popen::python_binary }
+  ensure
+    ENV['PATH'] = path_backup
+  end
+
   def test_styles
     assert P.styles.include?('colorful')
   end


### PR DESCRIPTION
I have python v3 installed on my path before python v2 and don't have a python2 binary, so I was getting weird behavior and failing tests (`MentosError: Failed to get header.` a la #45)

A library I wrote for command-line dependency version detection called `cliver` seems to be a good solution here. If python v 2.x cannot be found, it raises an exception that informs the user of the failed dependency in a sensible manner. Cliver avoids shelling out to `which`, and is therefore also more cross-compatible.
