### PR TITLE
Replace Yajl dependency with MultiJson

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -1,6 +1,6 @@
 # coding: utf-8
 require 'posix/spawn'
-require 'yajl'
+require 'multi_json'
 require 'timeout'
 require 'logger'
 require 'time'
@@ -232,7 +232,7 @@ module Pygments
 
           kwargs.freeze
           kwargs = kwargs.merge("fd" => @out.to_i, "id" => id, "bytes" => bytesize)
-          out_header = Yajl.dump(:method => method, :args => args, :kwargs => kwargs)
+          out_header = MultiJson.dump(:method => method, :args => args, :kwargs => kwargs)
 
           # Get the size of the header itself and write that.
           bits = get_fixed_bits_from_header(out_header)
@@ -372,7 +372,7 @@ module Pygments
     # want them, text otherwise.
     def return_result(res, method)
       unless method == :lexer_name_for || method == :highlight || method == :css
-        res = Yajl.load(res, :symbolize_keys => true)
+        res = MultiJson.load(res, :symbolize_keys => true)
       end
       res = res.rstrip if res.class == String
       res
@@ -381,7 +381,7 @@ module Pygments
     # Convert a text header into JSON for easy access.
     def header_to_json(header)
       @log.info "[#{Time.now.iso8601}] In header: #{header.to_s} "
-      header = Yajl.load(header)
+      header = MultiJson.load(header)
 
       if header["error"]
         # Raise this as a Ruby exception of the MentosError class.

--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.authors = ['Aman Gupta', 'Ted Nyman']
   s.email = ['aman@tmm1.net']
 
-  s.add_dependency 'yajl-ruby',   '~> 1.1.0'
+  s.add_dependency 'multi_json',  '~> 1.7'
   s.add_dependency 'posix-spawn', '~> 0.3.6'
   s.add_development_dependency 'rake-compiler', '~> 0.7.6'
 


### PR DESCRIPTION
In order to allow user to decide which JSON parser/encoder to use this commit replaces Yajl dependency with MultiJson.
