### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.authors = ['Aman Gupta', 'Ted Nyman']
   s.email = ['aman@tmm1.net']
+  s.license = 'MIT'
 
   s.add_dependency 'yajl-ruby',   '~> 1.1.0'
   s.add_dependency 'posix-spawn', '~> 0.3.6'


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
