### PR TITLE
use HTTPS for URL in gemspec

### DIFF
--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.summary = 'pygments wrapper for ruby'
   s.description = 'pygments.rb exposes the pygments syntax highlighter to Ruby'
 
-  s.homepage = 'http://github.com/tmm1/pygments.rb'
+  s.homepage = 'https://github.com/tmm1/pygments.rb'
   s.has_rdoc = false
 
   s.authors = ['Aman Gupta', 'Ted Nyman']


### PR DESCRIPTION
This pull request updates the pygments.rb gemspec metadata to use an encrypted HTTPS URL for the gem's homepage.
