### PR TITLE
Bump yajl-ruby dependency from 1.1.0 -> 1.2.0

### DIFF
--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.authors = ['Aman Gupta', 'Ted Nyman']
   s.email = ['aman@tmm1.net']
 
-  s.add_dependency 'yajl-ruby',   '~> 1.1.0'
+  s.add_dependency 'yajl-ruby',   '~> 1.2.0'
   s.add_dependency 'posix-spawn', '~> 0.3.6'
   s.add_development_dependency 'rake-compiler', '~> 0.7.6'
 


### PR DESCRIPTION
yajl-ruby 1.2.0 was recently released and contains a number of changes:

  https://github.com/brianmario/yajl-ruby/compare/eef5c48be81b6404af66da3f185ec9301e5214d8...fb61daad73340968badf6f84e41ec6931db2e87e