### PR TITLE
Invoke mentos directly on GNU/Linux

### DIFF
--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 import sys, re, os, signal

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -36,19 +36,10 @@ module Pygments
 
       # A pipe to the mentos python process. #popen4 gives us
       # the pid and three IO objects to write and read.
-      script = "#{python_binary} #{File.expand_path('../mentos.py', __FILE__)}"
+      script = "#{File.expand_path('../mentos.py', __FILE__)}"
+      script = "python " + script if is_windows
       @pid, @in, @out, @err = popen4(script)
       @log.info "[#{Time.now.iso8601}] Starting pid #{@pid.to_s} with fd #{@out.to_i.to_s}."
-    end
-
-    # Detect a suitable Python binary to use. We can't just use `python2`
-    # because apparently some old versions of Debian only have `python` or
-    # something like that.
-    def python_binary
-      @python_binary ||= begin
-        `which python2`
-        $?.success? ? "python2" : "python"
-      end
     end
 
     # Stop the child process by issuing a kill -9.


### PR DESCRIPTION
Invoking the script on GNU/Linux by passing it as an argument to
python(2) makes the process use 100% CPU for about tens of
seconds when it is supposed to timeout (test_returns_nil_on_timeout
reproduces this).

On current Debian Sid python2 exists, so this can be used in mentos.py
shebang.

Brought back script invocation for windows.
