### PR TITLE
add timeout configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 A Ruby wrapper for the Python [pygments syntax highlighter](http://pygments.org/).
 
-pygments.rb works by talking over a simple pipe to a long-lived 
+pygments.rb works by talking over a simple pipe to a long-lived
 Python child process. This library replaces [github/albino](https://github.com/github/albino),
 as well as a version of pygments.rb that used an embedded Python
-interpreter. 
+interpreter.
 
-Each Ruby process that runs has its own 'personal Python'; 
-for example, 4 Unicorn workers will have one Python process each. 
-If a Python process dies, a new one will be spawned on the next 
+Each Ruby process that runs has its own 'personal Python';
+for example, 4 Unicorn workers will have one Python process each.
+If a Python process dies, a new one will be spawned on the next
 pygments.rb request.
 
 ## system requirements
@@ -19,9 +19,9 @@ pygments.rb request.
 
 ## usage
 
-``` ruby 
+``` ruby
 require 'pygments'
-``` 
+```
 
 ``` ruby
 Pygments.highlight(File.read(__FILE__), :lexer => 'ruby')
@@ -34,7 +34,7 @@ options hash:
 Pygments.highlight('code', :options => {:encoding => 'utf-8'})
 ```
 
-pygments.rb defaults to using an HTML formatter. 
+pygments.rb defaults to using an HTML formatter.
 To use a formatter other than `html`, specify it explicitly
 like so:
 
@@ -57,7 +57,7 @@ Pygments.css(:style => "monokai")
 ```
 
 Other Pygments high-level API methods are also available.
-These methods return arrays detailing all the available lexers, formatters, 
+These methods return arrays detailing all the available lexers, formatters,
 and styles.
 
 ``` ruby
@@ -76,7 +76,12 @@ Pygments.start("/path/to/pygments")
 If you'd like logging, set the environmental variable `MENTOS_LOG` to a file path for your logfile.
 
 By default pygments.rb will timeout calls to pygments that take over 8 seconds. You can change this
-by setting the environmental variable `MENTOS_TIMEOUT` to a different positive integer value.
+by setting the environmental variable `MENTOS_TIMEOUT` to a different positive integer value or by
+passing the `:timeout` option (taking precedence over `MENTOS_TIMEOUT`):
+
+``` ruby
+Pygments.highlight('code', :timeout => 4)
+```
 
 ## benchmarks
 
@@ -105,17 +110,17 @@ The MIT License (MIT)
 
 Copyright (c) Ted Nyman and Aman Gupta, 2012-2013
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -214,7 +214,7 @@ module Pygments
 
       begin
         # Timeout requests that take too long.
-        timeout_time = ENV["MENTOS_TIMEOUT"] || 8
+        timeout_time = kwargs.delete(:timeout) || ENV["MENTOS_TIMEOUT"] || 8
 
         Timeout::timeout(timeout_time) do
           # For sanity checking on both sides of the pipe when highlighting, we prepend and

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -41,6 +41,15 @@ class PygmentsHighlightTest < Test::Unit::TestCase
     assert_equal nil, code
   end
 
+  def test_supports_configurable_timeout
+    code = P.highlight(REDIS_CODE)
+    assert_match 'used_memory_peak_human', code
+    assert_equal 455203, code.bytesize.to_i
+    # Assume highlighting a large file will take more than 1 millisecond
+    code = P.highlight(REDIS_CODE, :timeout => 0.001)
+    assert_equal nil, code
+  end
+
   def test_highlight_works_with_null_bytes
     code = P.highlight("\0hello", :lexer => 'rb')
     assert_match "hello", code


### PR DESCRIPTION
This PR adds a `:timeout` option that can be passed to `Pygments.highlight`. I also added a bit of a hacky unit test for the new functionality. The other unit test for testing timeouts is similarly presumptive (about how long/short a given machine is likely to take to highlight a block of code), but let me know if you would prefer another approach.

/cc @tnm 
