### PR TITLE
Force timeout_time to be int.

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -215,7 +215,7 @@ module Pygments
 
       begin
         # Timeout requests that take too long.
-        timeout_time = ENV["MENTOS_TIMEOUT"] || 8
+        timeout_time = ENV["MENTOS_TIMEOUT"].to_i || 8
 
         Timeout::timeout(timeout_time) do
           # For sanity checking on both sides of the pipe when highlighting, we prepend and

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -215,7 +215,7 @@ module Pygments
 
       begin
         # Timeout requests that take too long.
-        timeout_time = ENV["MENTOS_TIMEOUT"].to_i || 8
+	timeout_time = Integer(ENV["MENTOS_TIMEOUT"]) rescue 8
 
         Timeout::timeout(timeout_time) do
           # For sanity checking on both sides of the pipe when highlighting, we prepend and

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -215,7 +215,7 @@ module Pygments
 
       begin
         # Timeout requests that take too long.
-	# Invalid MENTOS_TIMEOUT results in just using default.
+        # Invalid MENTOS_TIMEOUT results in just using default.
         timeout_time = Integer(ENV["MENTOS_TIMEOUT"]) rescue 8
 
         Timeout::timeout(timeout_time) do

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -215,7 +215,8 @@ module Pygments
 
       begin
         # Timeout requests that take too long.
-	timeout_time = Integer(ENV["MENTOS_TIMEOUT"]) rescue 8
+	# Invalid MENTOS_TIMEOUT results in just using default.
+        timeout_time = Integer(ENV["MENTOS_TIMEOUT"]) rescue 8
 
         Timeout::timeout(timeout_time) do
           # For sanity checking on both sides of the pipe when highlighting, we prepend and


### PR DESCRIPTION
Fix type error I got from having `MENTOS_TIMEOUT` set:

```console
/Users/chen/.rubies/ruby-2.1.2/lib/ruby/2.1.0/timeout.rb:76:in `timeout': undefined method `zero?' for "100":String (NoMethodError)
	from /Users/chen/.gem/ruby/2.1.2/gems/pygments.rb-0.6.0/lib/pygments/popen.rb:220:in `mentos'
$ echo $MENTOS_TIMEOUT
100
```