### PR TITLE
Use PyPy if available

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -41,13 +41,19 @@ module Pygments
       @log.info "[#{Time.now.iso8601}] Starting pid #{@pid.to_s} with fd #{@out.to_i.to_s}."
     end
 
-    # Detect a suitable Python binary to use. We can't just use `python2`
-    # because apparently some old versions of Debian only have `python` or
-    # something like that.
+    # Detect a suitable Python binary to use.
     def python_binary
       @python_binary ||= begin
-        `which python2`
-        $?.success? ? "python2" : "python"
+        # pypy is faster than CPython, so use that if it's available.
+        `which pypy`
+        if $?.success?
+          "pypy"
+        else
+          # We can't just use `python2` because apparently some old versions of
+          # Debian only have `python` or something like that.
+          `which python2`
+          $?.success? ? "python2" : "python"
+        end
       end
     end
 


### PR DESCRIPTION
It's slower to launch than CPython, but around 30% faster once running.

CPython:

```
$ bundle exec ruby bench.rb
Benchmarking....
Size: 15523 bytes
Iterations: 10
                                               user     system      total        real
pygments popen                               0.010000   0.010000   0.020000 (  0.555983)
pygments popen (process already started)     0.000000   0.000000   0.000000 (  0.241948)
pygments popen (process already started 2)   0.010000   0.000000   0.010000 (  0.232061)

$ bundle exec ruby bench.rb 20 25
Benchmarking....
Size: 388075 bytes
Iterations: 20
                                               user     system      total        real
pygments popen                               0.080000   0.040000   0.130000 ( 11.803712)
pygments popen (process already started)     0.090000   0.040000   0.130000 ( 11.600885)
pygments popen (process already started 2)   0.090000   0.040000   0.130000 ( 11.567272)
```

PyPy:

```
$ bundle exec ruby bench.rb
Benchmarking....
Size: 15523 bytes
Iterations: 10
                                               user     system      total        real
pygments popen                               0.010000   0.000000   0.020000 (  0.997430)
pygments popen (process already started)     0.010000   0.000000   0.010000 (  0.366487)
pygments popen (process already started 2)   0.000000   0.010000   0.010000 (  0.273575)

$ bundle exec ruby bench.rb 20 25
Benchmarking....
Size: 388075 bytes
Iterations: 20
                                               user     system      total        real
pygments popen                               0.080000   0.030000   0.110000 (  9.264323)
pygments popen (process already started)     0.080000   0.040000   0.120000 (  7.407072)
pygments popen (process already started 2)   0.080000   0.030000   0.110000 (  7.446369)
```

/cc @tmm1 @tnm
