### PR TITLE
ArgumentError prevention

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -135,6 +135,8 @@ module Pygments
         Marshal.load(raw)
       rescue Errno::ENOENT
         raise MentosError, "Error loading lexer file. Was it created and vendored?"
+      rescue ArgumentError
+        lexers!
       end
     end
 


### PR DESCRIPTION
To prevent

/lib/ruby/gems/2.1.0/gems/pygments.rb-0.6.1/lib/pygments/popen.rb:124:in `load': marshal data too short (ArgumentError)

error, caused by different marshaling binary formats used by different Ruby interpreters.