### PR TITLE
Enhancing C++ lexer for include directives

### DIFF
--- a/vendor/pygments-main/pygments/lexers/compiled.py
+++ b/vendor/pygments-main/pygments/lexers/compiled.py
@@ -131,6 +131,7 @@ class CFamilyLexer(RegexLexer):
             (r'\\', String), # stray backslash
         ],
         'macro': [
+            (r'(include)(' + _ws1 + ')([^\n]+)', bygroups(Comment.Preproc, Text, Comment.PreprocFile)),
             (r'[^/\n]+', Comment.Preproc),
             (r'/[*](.|\n)*?[*]/', Comment.Multiline),
             (r'//.*?\n', Comment.Single, '#pop'),

--- a/vendor/pygments-main/pygments/token.py
+++ b/vendor/pygments-main/pygments/token.py
@@ -181,6 +181,7 @@ STANDARD_TYPES = {
     Comment:                       'c',
     Comment.Multiline:             'cm',
     Comment.Preproc:               'cp',
+    Comment.PreprocFile:           'cpf',
     Comment.Single:                'c1',
     Comment.Special:               'cs',
 


### PR DESCRIPTION
Hi, I'm using Pygments indirectly through Github pages for my blog and since I wanted to have a different style for include directives and their respective include files, I changed some lines in the lexer itself. To make it clear I wanted to add a custom styling to the file path in the include directives

![](http://marcodiiga.github.io/images/posts/enhancingpygments1.png)

in order to make it look like

![](http://marcodiiga.github.io/images/posts/enhancingpygments2.png)

If there are no other problems with this change, it's a 2-lines enhancement and could be useful to people who need some additional C++ syntax highlighting.

Thanks!