### PR TITLE
Detect python 2.5, 2.6, and 2.7 altinstalls

### DIFF
--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -47,7 +47,7 @@ module Pygments
       if is_windows && which('py')
         return 'py -2'
       end
-      return which('python2') || 'python'
+      return which('python2') || which('python25') || which('python26') || which('python27') || 'python'
     end
 
     # Cross platform which command


### PR DESCRIPTION
Python `make altinstall` installs a `python25`, `python26`, `python27` for versions 2.5, 2.6, and 2.7.  Additional versions are usually installed this way to avoid conflict with the OS's built in python.