### PR TITLE
Updating lexers on Windows

### DIFF
--- a/cache-lexers.rb
+++ b/cache-lexers.rb
@@ -4,5 +4,5 @@ require File.join(File.dirname(__FILE__), '/lib/pygments.rb')
 serialized_lexers = Marshal.dump(Pygments.lexers!)
 
 # Write to a file
-File.open("lexers", 'w') { |file| file.write(serialized_lexers) }
+File.open("lexers", 'wb') { |file| file.write(serialized_lexers) }
 


### PR DESCRIPTION
Pygments.rb fails with `dump format error(0xa)` after updating lexers cache on Windows.
This is caused by automatic LF->CRLF conversion.
Setting binary file mode in cache-lexers.rb disables LF conversion on Windows.
