### PR TITLE
Remove warnings

### DIFF
--- a/lib/pygments/lexer.rb
+++ b/lib/pygments/lexer.rb
@@ -36,9 +36,9 @@ module Pygments
           extnames << extname
         end
 
-        extnames.each do |extname|
-          @extname_index[extname] = lexer
-          @index[extname.downcase.sub(/^\./, "")] ||= lexer
+        extnames.each do |the_extname|
+          @extname_index[the_extname] = lexer
+          @index[the_extname.downcase.sub(/^\./, "")] ||= lexer
         end
       end
 

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -97,7 +97,7 @@ module Pygments
     #
     # Returns true if the child is alive.
     def alive?
-      return true if @pid && Process.kill(0, @pid)
+      return true if defined?(@pid) && @pid && Process.kill(0, @pid)
       false
     rescue Errno::ENOENT, Errno::ESRCH
       false

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -230,7 +230,7 @@ class PygmentsLexerClassTest < Test::Unit::TestCase
     assert_equal P::Lexer['Ruby'], P::Lexer.find_by_mimetype('text/x-ruby')
     assert_equal P::Lexer['JSON'], P::Lexer.find_by_mimetype('application/json')
     assert_equal P::Lexer['Python'], P::Lexer.find_by_mimetype('text/x-python')
-  end
+ end
 end
 
 
@@ -238,19 +238,19 @@ class PygmentsCssTest < Test::Unit::TestCase
   include Pygments
 
   def test_css
-    assert_match /^\.err \{/, P.css
+    assert_match(/^\.err \{/, P.css)
   end
 
   def test_css_prefix
-    assert_match /^\.highlight \.err \{/, P.css('.highlight')
+    assert_match(/^\.highlight \.err \{/, P.css('.highlight'))
   end
 
   def test_css_options
-    assert_match /^\.codeerr \{/, P.css(:classprefix => 'code')
+    assert_match(/^\.codeerr \{/, P.css(:classprefix => 'code'))
   end
 
   def test_css_prefix_and_options
-    assert_match /^\.mycode \.codeerr \{/, P.css('.mycode', :classprefix => 'code')
+    assert_match(/^\.mycode \.codeerr \{/, P.css('.mycode', :classprefix => 'code'))
   end
 
   def test_css_default


### PR DESCRIPTION
Spotted while running tests (with Rake version >= 11.2.2):

```
- pygments.rb-0.6.3/lib/pygments/lexer.rb:39: warning: shadowing outer local variable - extname
- pygments.rb-0.6.3/lib/pygments/popen.rb:100: warning: instance variable @pid not initialized
```