### PR TITLE
resolves #99 add support for JRuby

### DIFF
--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -14,9 +14,15 @@ Gem::Specification.new do |s|
   s.email = ['aman@tmm1.net']
   s.license = 'MIT'
 
-  s.add_dependency 'yajl-ruby',   '~> 1.2.0'
-  s.add_dependency 'posix-spawn', '~> 0.3.6'
-  s.add_development_dependency 'rake-compiler', '~> 0.7.6'
+  if RUBY_ENGINE == 'jruby'
+    s.platform = 'java'
+    s.add_dependency 'multi_json', '~> 1.12.1'
+  else
+    s.add_dependency 'yajl-ruby',   '~> 1.2.0'
+    s.add_dependency 'posix-spawn', '~> 0.3.6'
+  end
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'test-unit'
 
   # s.extensions = ['ext/extconf.rb']
   s.require_paths = ['lib']


### PR DESCRIPTION
When RUBY_ENGINE == 'jruby', do the following:
- map popen4 function to Open.popen3
- map Yajl to MultiJson and set MultiJson engine to json_gem
- update gemspec to build -java gem when running under JRuby
- drop posix/spawn and yaml dependencies and add multi_json

Additionally, add rake and test-unit as development dependencies so rake and tests can be run via Bundler, respectively.
