### PR TITLE
Relax yajl-ruby dependency to `~> 1.2`

### DIFF
--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email = ['aman@tmm1.net']
   s.license = 'MIT'
 
-  s.add_dependency 'yajl-ruby',   '~> 1.2.0'
+  s.add_dependency 'yajl-ruby',   '~> 1.2'
   s.add_dependency 'posix-spawn', '~> 0.3.6'
   s.add_development_dependency 'rake-compiler', '~> 0.7.6'
 


### PR DESCRIPTION
`~> 1.2` also matches `1.3.0`, which `~> 1.2.0` does not.

yajl-ruby 1.3 adds support for Ruby 2.4 (handles Fixnum/Bignum -> Integer unification). See https://github.com/brianmario/yajl-ruby/pull/165 for details.