### PR TITLE
Thread Safety

### DIFF
--- a/lib/pygments.rb
+++ b/lib/pygments.rb
@@ -1,8 +1,33 @@
 require File.join(File.dirname(__FILE__), 'pygments/popen')
-
+require 'forwardable'
 
 module Pygments
-  extend Pygments::Popen
 
   autoload :Lexer, 'pygments/lexer'
+
+  class << self
+    extend Forwardable
+
+    def engine
+      Thread.current.thread_variable_get(:pygments_engine) ||
+        Thread.current.thread_variable_set(:pygments_engine, Pygments::Popen.new)
+    end
+
+    def_delegators :engine,
+      # public
+      :formatters,
+      :lexers,
+      :lexers!,
+      :filters,
+      :styles,
+      :css,
+      :lexer_name_for,
+      :highlight,
+      # not public but documented
+      :start,
+      # only for testing
+      :size_check,
+      :get_fixed_bits_from_header,
+      :add_ids
+  end
 end

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -12,8 +12,7 @@ end
 # Pygments provides access to the Pygments library via a pipe and a long-running
 # Python process.
 module Pygments
-  module Popen
-    extend self
+  class Popen
 
     def popen4(cmd)
       stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -111,6 +111,17 @@ class PygmentsHighlightTest < Test::Unit::TestCase
     code = P.highlight("importr python;    wat?", :lexer => 'py')
     assert_match ">importr</span>", code
   end
+
+  def test_highlight_on_multi_threads
+    10.times.map do
+      Thread.new do
+        test_full_html_highlight
+      end
+    end.each do |thread|
+      thread.join
+    end
+  end
+
 end
 
 # Philosophically, I'm not the biggest fan of testing private


### PR DESCRIPTION
Make pygments.rb thread-safe by instantiating Pygments::Popen per-thread.

NOTE: it does not change public methods but the internal is significantly changed.