### PR TITLE
Fix formatting in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-changelog
+CHANGELOG
 ===========
 
 Version 1.1.2 (2017/04/03)
+-----------------------------
 
 * Resolves #176 exclude find_error.py symlink from gem [#177](https://github.com/tmm1/pygments.rb/pull/177)
 


### PR DESCRIPTION
1. Fix the formatting of the last CHANGELOG entry.
2. Change the **changelog** title to **CHANGELOG**, which seems to be how it's usually presented.