### PR TITLE
exclude symlinks without find(1)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,5 +63,6 @@ namespace :vendor do
     FileUtils.cd(LEXERS_DIR) { sh "python _mapping.py" }
   end
 
+  desc 'update vendor/pygments-main'
   task :update => [:clobber, 'vendor/pygments-main', :load_lexers]
 end

--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |s|
   # s.extensions = ['ext/extconf.rb']
   s.require_paths = ['lib']
 
-  exclude = `find . -type l -printf '%P\\0'`.split("\0").map {|f| "':!#{f}'" } * ' '
-  s.files = `git ls-files -- . #{exclude}`.split("\n")
+  s.files = `git ls-files`.split("\n").select { |f| !File.symlink?(f) }
 end


### PR DESCRIPTION
That's because `find(1)` is not portable.