### PR TITLE
Add GitHub Actions CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        ruby: [2.4, 2.5, 2.6, 2.7]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: eregon/use-ruby-action@master
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 2.7
+      - name: Build and Test
+        shell: bash
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+          bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# pygments.rb [![CircleCI](https://circleci.com/gh/tmm1/pygments.rb.svg?style=svg)](https://circleci.com/gh/tmm1/pygments.rb) [![Gem Version](https://badge.fury.io/rb/pygments.rb.svg)](https://badge.fury.io/rb/pygments.rb)
+# pygments.rb [![CircleCI][circleci_badge]][circleci_url] [![GitHub Actions][gh-actions_badge]][gh-actions_url] [![Gem Version][gem_badge]][gem_url]
+
+[circleci_badge]: https://circleci.com/gh/tmm1/pygments.rb.svg?style=svg
+[circleci_url]: https://circleci.com/gh/tmm1/pygments.rb
+[gh-actions_badge]: https://github.com/tmm1/pygments.rb/workflows/CI/badge.svg
+[gh-actions_url]: https://github.com/tmm1/pygments.rb/actions?query=workflow%3ACI
+[gem_badge]: https://badge.fury.io/rb/pygments.rb.svg
+[gem_url]: https://badge.fury.io/rb/pygments.rb
 
 A Ruby wrapper for the Python [pygments syntax highlighter](http://pygments.org/).
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,6 @@ require 'rubygems/package_task'
 require 'rake/testtask'
 Rake::TestTask.new 'test' do |t|
   t.test_files = FileList['test/test_*.rb']
-  t.ruby_opts = ['-rubygems']
 end
 
 # ==========================================================

--- a/pygments.rb.gemspec
+++ b/pygments.rb.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.description = 'pygments.rb exposes the pygments syntax highlighter to Ruby'
 
   s.homepage = 'https://github.com/tmm1/pygments.rb'
-  s.has_rdoc = false
 
   s.authors = ['Aman Gupta', 'Ted Nyman']
   s.email = ['aman@tmm1.net']


### PR DESCRIPTION
eregon/use-ruby-action is used in workflow instead of more common actions/setup-ruby
because the latter doesn't yet support Ruby 2.7. See actions/setup-ruby#45