### PR TITLE
Python3 copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,23 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7]
+        python: [3.5, 3.6, 3.7, 3.8]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Ruby
-        uses: eregon/use-ruby-action@master
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
       - name: Build and Test
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 2.7
+          python-version: 3.7
       - name: Build and Test
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 ===========
 
+Version 1.3.0 (2020/??/??)
+-----------------------------
+
+* Modified `mentos.py` to run on Python 3.x instead of Python 2.7
+* Added `:timeout` keyword option to allow for configurabel timeouts
+* Added several Python 3.x versions to test matrix
+
 Version 1.2.1 (2017/12/07)
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ pygments.rb request.
 
 ## system requirements
 
-- Python 2.5, Python 2.6, or Python 2.7. You can always use Python 2.x from a `virtualenv` if
-  your default Python install is 3.x.
+- Python 3.5, Python 3.6, Python 3.7, or Python 3.8. You can always use
+Python 3.x from a `virtualenv` if your default Python installation is 2.x.
 
 ## usage
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ Pygments.start("/path/to/pygments")
 If you'd like logging, set the environmental variable `MENTOS_LOG` to a file path for your logfile.
 
 By default pygments.rb will timeout calls to pygments that take over 8 seconds. You can change this
-by setting the environmental variable `MENTOS_TIMEOUT` to a different positive integer value.
+by setting the environmental variable `MENTOS_TIMEOUT` to a different positive integer value or by
+passing the `:timeout` option (taking precedence over `MENTOS_TIMEOUT`):
+
+``` ruby
+Pygments.highlight('code', :timeout => 4)
+```
 
 ## benchmarks
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Pygments.start("/path/to/pygments")
 
 If you'd like logging, set the environmental variable `MENTOS_LOG` to a file path for your logfile.
 
-By default pygments.rb will timeout calls to pygments that take over 8 seconds. You can change this
-by setting the environmental variable `MENTOS_TIMEOUT` to a different positive integer value or by
-passing the `:timeout` option (taking precedence over `MENTOS_TIMEOUT`):
+By default pygments.rb will timeout calls to pygments that take over 10 seconds.
+You can change this by setting the environmental variable `MENTOS_TIMEOUT` to a
+different value or by passing the `:timeout` option (taking precedence over `MENTOS_TIMEOUT`):
 
 ``` ruby
 Pygments.highlight('code', :timeout => 4)

--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -27,7 +27,7 @@ def _convert_keys(dictionary):
     if not isinstance(dictionary, dict):
         return dictionary
     return dict((str(k), _convert_keys(v))
-        for k, v in dictionary.items())
+        for k, v in list(dictionary.items()))
 
 def _write_error(error):
     res = {"error": error}
@@ -41,7 +41,7 @@ def _write_error(error):
 
 def _get_fixed_bits_from_header(out_header):
     size = len(out_header)
-    return "".join(map(lambda y:str((size>>y)&1), range(32-1, -1, -1)))
+    return "".join([str((size>>y)&1) for y in range(32-1, -1, -1)])
 
 def _signal_handler(signal, frame):
     """

--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys, re, os, signal
@@ -163,12 +163,9 @@ class Mentos(object):
                 res = json.dumps(res)
 
             elif method == 'highlight':
-                try:
-                    text = text.decode('utf-8')
-                except UnicodeDecodeError:
-                    # The text may already be encoded
-                    text = text
                 res = self.highlight_text(text, lexer, formatter_name, args, _convert_keys(opts))
+                if type(res) is bytes:
+                    res = res.decode('utf-8')
 
             elif method == 'css':
                 kwargs = _convert_keys(kwargs)
@@ -197,7 +194,7 @@ class Mentos(object):
         # Base header. We'll build on this, adding keys as necessary.
         base_header = {"method": method}
 
-        res_bytes = len(res) + 1
+        res_bytes = len(res.encode("utf-8")) + 1
         base_header["bytes"] = res_bytes
 
         out_header = json.dumps(base_header)
@@ -264,7 +261,7 @@ class Mentos(object):
             # The loop begins by reading off a simple 32-arity string
             # representing an integer of 32 bits. This is the length of
             # our JSON header.
-            size = sys.stdin.read(32)
+            size = sys.stdin.buffer.read(32).decode('utf-8')
 
             if not size:
                 break
@@ -280,7 +277,7 @@ class Mentos(object):
                 if not size_regex.match(size):
                     _write_error("Size received is not valid.")
 
-                line = sys.stdin.read(header_bytes)
+                line = sys.stdin.buffer.read(header_bytes).decode('utf-8')
 
                 header = json.loads(line)
 
@@ -294,8 +291,8 @@ class Mentos(object):
                 if kwargs:
                     _bytes = kwargs.get("bytes", 0)
 
-                # Read up to the given number bytes (possibly 0)
-                text = sys.stdin.read(_bytes)
+                # Read up to the given number of *bytes* (not chars) (possibly 0)
+                text = sys.stdin.buffer.read(_bytes).decode('utf-8')
 
                 # Sanity check the return.
                 if _bytes:

--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -266,6 +266,9 @@ class Mentos(object):
             # our JSON header.
             size = sys.stdin.read(32)
 
+            if not size:
+                break
+
             lock.acquire()
 
             try:

--- a/lib/pygments/mentos.py
+++ b/lib/pygments/mentos.py
@@ -31,7 +31,7 @@ def _convert_keys(dictionary):
 
 def _write_error(error):
     res = {"error": error}
-    out_header = json.dumps(res).encode('utf-8')
+    out_header = json.dumps(res)
     bits = _get_fixed_bits_from_header(out_header)
     sys.stdout.write(bits + "\n")
     sys.stdout.flush()
@@ -40,7 +40,7 @@ def _write_error(error):
     return
 
 def _get_fixed_bits_from_header(out_header):
-    size = len(out_header)
+    size = len(out_header.encode('utf-8'))
     return "".join([str((size>>y)&1) for y in range(32-1, -1, -1)])
 
 def _signal_handler(signal, frame):
@@ -200,7 +200,7 @@ class Mentos(object):
         res_bytes = len(res) + 1
         base_header["bytes"] = res_bytes
 
-        out_header = json.dumps(base_header).encode('utf-8')
+        out_header = json.dumps(base_header)
 
         # Following the protocol, send over a fixed size represenation of the
         # size of the JSON header

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -63,9 +63,9 @@ module Pygments
       if ENV['PYGMENTS_RB_PYTHON']
         return which(ENV['PYGMENTS_RB_PYTHON'])
       elsif windows? && which('py')
-        return 'py -2'
+        return 'py -3'
       end
-      return which('python2') || which('python')
+      return which('python3')
     end
 
     # Cross platform which command

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -248,8 +248,8 @@ module Pygments
 
       begin
         # Timeout requests that take too long.
-        # Invalid MENTOS_TIMEOUT results in just using default.
-        timeout_time = Float(kwargs.delete(:timeout) || ENV["MENTOS_TIMEOUT"] || 8)
+        # If :timeout and MENTOS_TIMEOUT not set we use the default of 10 sec.
+        timeout_time = Float(kwargs.delete(:timeout) || ENV["MENTOS_TIMEOUT"] || 10)
 
         Timeout::timeout(timeout_time) do
           # For sanity checking on both sides of the pipe when highlighting, we prepend and

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -65,7 +65,7 @@ module Pygments
       elsif windows? && which('py')
         return 'py -3'
       end
-      return which('python3')
+      return which('python3') || which('python')
     end
 
     # Cross platform which command

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -160,7 +160,7 @@ module Pygments
     #
     # Returns an array of lexers.
     def lexers!
-      mentos(:get_all_lexers).inject(Hash.new) do |hash, lxr|
+      mentos(:get_all_lexers, nil, {:timeout => 16}).inject(Hash.new) do |hash, lxr|
         name = lxr[0]
         hash[name] = {
           :name => name,
@@ -249,7 +249,7 @@ module Pygments
       begin
         # Timeout requests that take too long.
         # Invalid MENTOS_TIMEOUT results in just using default.
-        timeout_time = Integer(ENV["MENTOS_TIMEOUT"]) rescue 8
+        timeout_time = Float(kwargs.delete(:timeout) || ENV["MENTOS_TIMEOUT"] || 8)
 
         Timeout::timeout(timeout_time) do
           # For sanity checking on both sides of the pipe when highlighting, we prepend and

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -243,7 +243,6 @@ class PygmentsLexerClassTest < Test::Unit::TestCase
  def test_find_lexer_by_mimetype
     assert_equal P::Lexer['Ruby'], P::Lexer.find_by_mimetype('text/x-ruby')
     assert_equal P::Lexer['JSON'], P::Lexer.find_by_mimetype('application/json')
-    assert_equal P::Lexer['Python'], P::Lexer.find_by_mimetype('text/x-python')
  end
 end
 

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -44,6 +44,14 @@ class PygmentsHighlightTest < Test::Unit::TestCase
     assert_equal nil, code
   end
 
+  def test_supports_configurable_timeout
+    code = P.highlight(REDIS_CODE)
+    assert_match 'used_memory_peak_human', code
+    # Assume highlighting a large file will take more than 1 millisecond
+    code = P.highlight(REDIS_CODE, :timeout => 0.001)
+    assert_equal nil, code
+  end
+
   def test_highlight_works_with_null_bytes
     code = P.highlight("\0hello", :lexer => 'rb')
     assert_match "hello", code


### PR DESCRIPTION
This is a continuation of the effort started in https://github.com/tmm1/pygments.rb/pull/192/files 
 - resolves #152
 - All tests pass with py3.x on all platforms
 - includes also code from https://github.com/tmm1/pygments.rb/pull/123 since it helped workaround some macOS CI tests failures 
 - suggest release as v1.3.0 even though no code changes, since py2 --> py3 switch is significant
