### PR TITLE
resolves #130 rely on shebang for finding and error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 * Update Pygments to 2.7.3
 * Drop GitHub custom lexers
 * Rework timeout handling
+* Improve error message when Python is not found
 
 Version 1.2.1 (2017/12/07)
 -----------------------------

--- a/lib/pygments/popen.rb
+++ b/lib/pygments/popen.rb
@@ -54,15 +54,13 @@ module Pygments
     end
 
     # Detect a suitable Python binary to use.
-    # Or return $PYGMENTS_RB_PYTHON if it's exists.
     def find_python_binary
-      if ENV['PYGMENTS_RB_PYTHON']
-        return which(ENV['PYGMENTS_RB_PYTHON'])
-      elsif Gem.win_platform? && which('py')
-        return %w[py -3]
+      if Gem.win_platform?
+        return %w[py python3 python].first { |py| !which(py).nil? }
       end
 
-      which('python3') || which('python')
+      # On non-Windows platforms, we simply rely on shebang
+      []
     end
 
     # Cross platform which command

--- a/test/test_pygments.rb
+++ b/test/test_pygments.rb
@@ -116,7 +116,7 @@ class PygmentsHighlightTest < Test::Unit::TestCase
   end
 
   def test_highlight_on_multi_threads
-    omit "We do not actually support multithreading"
+    omit 'We do not actually support multithreading'
 
     10.times.map do
       Thread.new do


### PR DESCRIPTION
Now if user doesn't have Python in PATH, they'll get something like:

```
/home/runner/work/pygments.rb/pygments.rb/lib/pygments/popen.rb:328:in `rescue in mentos': Broken pipe: /usr/bin/env: ‘python3’: No such file or directory (MentosError)
	from /home/runner/work/pygments.rb/pygments.rb/lib/pygments/popen.rb:293:in `mentos'
	from /home/runner/work/pygments.rb/pygments.rb/lib/pygments/popen.rb:155:in `lexers!'
	from /opt/hostedtoolcache/Ruby/2.3.8/x64/lib/ruby/2.3.0/forwardable.rb:202:in `lexers!'
	from cache-lexers.rb:6:in `<main>'
```